### PR TITLE
feat: support `gh` CLI for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ brew install brows
 ```
 
 ## Configuration:
-
-  * (Required) Set the `GITHUB_OAUTH_TOKEN` environment variable to a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for access to the GitHub API.
+  * (Required) A GitHub auth token is required. It can be set by the `GITHUB_OAUTH_TOKEN` environment variable to a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) or, if the environment variable is not set, Brows will attempt to use the token from the [GitHub CLI](https://cli.github.com/) (`gh auth token`) if available (CLI installed and logged in).
   * (Optional) Create a config file at `$HOME/.config/brows.yml` and set a `default_org` key, like:
 
 ```

--- a/brows.go
+++ b/brows.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/rubysolo/brows/util"
+
 import (
 	"context"
 	"fmt"
@@ -464,10 +466,7 @@ func main() {
 		repo = parts[1]
 	}
 
-	token := os.Getenv("GITHUB_OAUTH_TOKEN")
-	if token == "" {
-		log.Fatal("no GITHUB_OAUTH_TOKEN provided.")
-	}
+	token := util.GetGHToken()
 
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(

--- a/util/github.go
+++ b/util/github.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const GITHUB_TOKEN_ENV = "GITHUB_OAUTH_TOKEN"
+const GH_CLI_COMMAND = "gh auth token"
+
+// GetToken retrieves a GitHub access token from the environment variable `GITHUB_OAUTH_TOKEN`.
+// If the environment variable is not set, it attempts to obtain the token by executing
+// the GitHub CLI `gh auth token` command. If both methods fail, the function terminates
+// the program with a fatal error, providing guidance for the user.
+func GetGHToken() string {
+	token := os.Getenv(GITHUB_TOKEN_ENV)
+	if token != "" {
+		return token
+	}
+
+
+	command_arr := strings.Split(GH_CLI_COMMAND, " ")
+	out, err := exec.Command(command_arr[0], command_arr[1:]...).Output()
+	if err != nil {
+		log.Fatal("GITHUB_OAUTH_TOKEN not set and failed to retrieve token from gh CLI: ", err, "\nPlease set GITHUB_OAUTH_TOKEN or run 'gh auth login'")
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		log.Fatal("GITHUB_OAUTH_TOKEN not set and gh CLI did not return a token.\nPlease set GITHUB_OAUTH_TOKEN or run 'gh auth login'")
+	}
+	return trimmed
+}


### PR DESCRIPTION

**Improvements to authentication token retrieval:**

* Added a new utility function `GetGHToken` in `util/github.go` that first checks for the `GITHUB_OAUTH_TOKEN` environment variable, and if not found, attempts to retrieve the token using the GitHub CLI `gh auth token`. If both methods fail, it logs a clear error message and exits.
* Updated the main application logic in `brows.go` to use the new `util.GetGHToken` function instead of directly reading the environment variable, improving robustness and user experience.

**Documentation updates:**

* Updated the `README.md` to explain the new authentication method, clarifying that either the environment variable or the GitHub CLI can be used to provide the token.

fixes #1 